### PR TITLE
feat: Add model_kwargs to llm_with_retry

### DIFF
--- a/llmutils/llm_with_retry.py
+++ b/llmutils/llm_with_retry.py
@@ -13,7 +13,7 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10))
-def call_llm_with_retry(model_name: str, prompt_message: str) -> str:
+def call_llm_with_retry(model_name: str, prompt_message: str, model_kwargs: dict = None) -> str:
     """
     Calls the LLM with the given model name and prompt message.
     Includes retrying with exponential backoff (3 tries, wait 2^x seconds between retries).
@@ -23,7 +23,8 @@ def call_llm_with_retry(model_name: str, prompt_message: str) -> str:
         llm = ChatOpenAI(
             model_name=model_name,
             openai_api_base="https://openrouter.ai/api/v1",
-            openai_api_key=os.environ.get("OPENROUTER_API_KEY")
+            openai_api_key=os.environ.get("OPENROUTER_API_KEY"),
+            model_kwargs=model_kwargs or {}
         )
         response = llm.invoke([HumanMessage(content=prompt_message)])
         logger.info("LLM call successful.")

--- a/tests/test_llm_with_retry.py
+++ b/tests/test_llm_with_retry.py
@@ -35,7 +35,33 @@ def test_call_llm_success_first_try(mock_chat_openai, mock_api_key):
     mock_chat_openai.assert_called_once_with(
         model_name="test-model",
         openai_api_base="https://openrouter.ai/api/v1",
-        openai_api_key="mock-api-key-for-testing"
+        openai_api_key="mock-api-key-for-testing",
+        model_kwargs={}
+    )
+    mock_llm_instance.invoke.assert_called_once()
+
+@patch('llmutils.llm_with_retry.ChatOpenAI')
+def test_call_llm_with_model_kwargs(mock_chat_openai, mock_api_key):
+    """
+    Tests that the function correctly passes model_kwargs to the ChatOpenAI constructor.
+    """
+    # Arrange
+    mock_response = AIMessage(content="This is a test response with model_kwargs.")
+    mock_llm_instance = MagicMock()
+    mock_llm_instance.invoke.return_value = mock_response
+    mock_chat_openai.return_value = mock_llm_instance
+    model_kwargs = {"temperature": 0.7, "top_p": 0.9}
+
+    # Act
+    result = call_llm_with_retry("test-model-kwargs", "Hello with kwargs!", model_kwargs=model_kwargs)
+
+    # Assert
+    assert result == "This is a test response with model_kwargs."
+    mock_chat_openai.assert_called_once_with(
+        model_name="test-model-kwargs",
+        openai_api_base="https://openrouter.ai/api/v1",
+        openai_api_key="mock-api-key-for-testing",
+        model_kwargs=model_kwargs
     )
     mock_llm_instance.invoke.assert_called_once()
 


### PR DESCRIPTION
Adds the ability to pass `model_kwargs` to the `call_llm_with_retry` function. This allows for greater flexibility in configuring the LLM, such as setting temperature or top_p.

The change defaults to an empty dictionary if no `model_kwargs` are provided to avoid TypeErrors in the underlying LangChain library.

Includes a new unit test to verify that the `model_kwargs` are passed correctly and updates an existing test to reflect the new default value.